### PR TITLE
Remove the Wayland post-cleanup hack

### DIFF
--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1355,25 +1355,6 @@ DispatchDeferredCleanup:
     m_VideoDecoder = nullptr;
     SDL_AtomicUnlock(&m_DecoderLock);
 
-    if (strcmp(SDL_GetCurrentVideoDriver(), "wayland") == 0) {
-        // HACK: SDL (as of 2.0.10) has a bug that causes Mutter not to destroy the window
-        // surface when in full-screen unless we render more frames after we request
-        // to exit full-screen. The amount of frames required is variable but 500 ms
-        // of frames seems sufficient in my testing.
-        SDL_SetWindowFullscreen(m_Window, 0);
-        SDL_Renderer* renderer = SDL_CreateRenderer(m_Window, -1, SDL_RENDERER_PRESENTVSYNC);
-        if (renderer != nullptr) {
-            SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
-            for (int i = 0; i < 10; i++)
-            {
-                SDL_RenderClear(renderer);
-                SDL_RenderPresent(renderer);
-                SDL_Delay(50);
-            }
-            SDL_DestroyRenderer(renderer);
-        }
-    }
-
     // This must be called after the decoder is deleted, because
     // the renderer may want to interact with the window
     SDL_DestroyWindow(m_Window);


### PR DESCRIPTION
It seems to do more harm than good on Fedora 32, causing deadlocks
when the stream is closed. The original bug it was trying to avoid
seems to have already been fixed.